### PR TITLE
Minor bug fix to prevent crash

### DIFF
--- a/AGImagePickerController/AGIPCAssetsController.m
+++ b/AGImagePickerController/AGIPCAssetsController.m
@@ -317,7 +317,12 @@
     [self changeSelectionInformation];
     
     NSInteger totalRows = [self.tableView numberOfRowsInSection:0];
-    [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:totalRows-1 inSection:0] atScrollPosition:UITableViewScrollPositionBottom animated:NO];
+    
+    //Prevents crash if totalRows = 0 (when the album is empty). 
+    if (totalRows > 0) {
+
+        [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:totalRows-1 inSection:0] atScrollPosition:UITableViewScrollPositionBottom animated:NO];
+    }
 }
 
 - (void)doneAction:(id)sender


### PR DESCRIPTION
If you tap on "Camera Roll" in "Albums" screen when Camera Roll is empty, the app would crash because of negative row value due to "-1" in NSIndexPath method: [NSIndexPath indexPathForRow:totalRows-1 inSection:0]. 

Solution is to check if rows are more than 0.
