### PR TITLE
Forgotten ivar added

### DIFF
--- a/AGImagePickerController/AGImagePickerController.h
+++ b/AGImagePickerController/AGImagePickerController.h
@@ -68,6 +68,7 @@ shouldShowToolbarForManagingTheSelectionInSelectionMode:(AGImagePickerController
 
 @property (nonatomic) BOOL shouldChangeStatusBarStyle;
 @property (nonatomic) BOOL shouldShowSavedPhotosOnTop;
+@property (nonatomic) BOOL shouldShowPhotosWithLocationOnly;
 @property (nonatomic) NSUInteger maximumNumberOfPhotosToBeSelected;
 
 @property (nonatomic, ag_weak) id delegate;


### PR DESCRIPTION
shouldShowPhotosWithLocationOnly wasn't defined in earlier commit.
More details here:
https://github.com/arturgrigor/AGImagePickerController/commit/3a7b566f823ef104d63e35a97561f468b29e78b0#commitcomment-3951127
